### PR TITLE
(TT-708) backfill tradelogs with selectable integration

### DIFF
--- a/cmd/tradelogs/main.go
+++ b/cmd/tradelogs/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/KyberNetwork/tradelogs/internal/bigquery"
 	"github.com/KyberNetwork/tradelogs/internal/dbutil"
 	"github.com/KyberNetwork/tradelogs/internal/evmlistenerclient"
+	"github.com/KyberNetwork/tradelogs/internal/parser"
 	"github.com/KyberNetwork/tradelogs/internal/parser/hashflow"
 	"github.com/KyberNetwork/tradelogs/internal/parser/kyberswap"
 	"github.com/KyberNetwork/tradelogs/internal/parser/paraswap"
@@ -81,16 +82,15 @@ func run(c *cli.Context) error {
 		return err
 	}
 
-	backfillWorker, err := bigquery.NewWorker(
-		libapp.BigqueryProjectIDFFromCli(c),
-		s,
-		kyberswap.MustNewParser(),
-		zxotc.MustNewParser(),
-		zxrfq.MustNewParser(),
-		tokenlon.MustNewParser(),
-		paraswap.MustNewParser(),
-		hashflow.MustNewParser(),
-	)
+	parserMap := map[string]parser.Parser{
+		"kyberswap": kyberswap.MustNewParser(),
+		"zxotc":     zxotc.MustNewParser(),
+		"zxrfq":     zxrfq.MustNewParser(),
+		"tokenlon":  tokenlon.MustNewParser(),
+		"paraswap":  paraswap.MustNewParser(),
+		"hashflow":  hashflow.MustNewParser(),
+	}
+	backfillWorker, err := bigquery.NewWorker(libapp.BigqueryProjectIDFFromCli(c), s, parserMap)
 	if err != nil {
 		l.Errorw("Error while init backfillWorker")
 		return err

--- a/internal/server/backfill/server.go
+++ b/internal/server/backfill/server.go
@@ -74,7 +74,10 @@ func (s *Server) backfill(c *gin.Context) {
 		return
 	}
 
-	exchanges := strings.Split(query.Exchanges, ",")
+	var exchanges []string
+	if query.Exchanges != "" {
+		exchanges = strings.Split(query.Exchanges, ",")
+	}
 	s.l.Infow("Request backfill", "query", query)
 	if query.FromTime == 0 || query.ToTime == 0 {
 		err = s.bq.BackFillAllData(exchanges)

--- a/internal/server/backfill/server.go
+++ b/internal/server/backfill/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/KyberNetwork/tradelogs/internal/bigquery"
@@ -62,8 +63,9 @@ func responseErr(c *gin.Context, err error) {
 func (s *Server) backfill(c *gin.Context) {
 	var (
 		query struct {
-			FromTime int64 `form:"from_time" json:"from_time,omitempty"` // milliseconds
-			ToTime   int64 `form:"to_time" json:"to_time,omitempty"`     // milliseconds
+			FromTime  int64  `form:"from_time" json:"from_time,omitempty"` // milliseconds
+			ToTime    int64  `form:"to_time" json:"to_time,omitempty"`     // milliseconds
+			Exchanges string `form:"exchanges" json:"exchanges,omitempty"`
 		}
 		err = c.ShouldBind(&query)
 	)
@@ -72,11 +74,12 @@ func (s *Server) backfill(c *gin.Context) {
 		return
 	}
 
+	exchanges := strings.Split(query.Exchanges, ",")
 	s.l.Infow("Request backfill", "query", query)
 	if query.FromTime == 0 || query.ToTime == 0 {
-		err = s.bq.BackFillAllData()
+		err = s.bq.BackFillAllData(exchanges)
 	} else {
-		err = s.bq.BackFillPartialData(query.FromTime/1000, query.ToTime/1000)
+		err = s.bq.BackFillPartialData(query.FromTime/1000, query.ToTime/1000, exchanges)
 	}
 	if err != nil {
 		responseErr(c, err)


### PR DESCRIPTION
```go
query struct {
			FromTime  int64  `form:"from_time" json:"from_time,omitempty"` // milliseconds
			ToTime    int64  `form:"to_time" json:"to_time,omitempty"`     // milliseconds
			Exchanges string `form:"exchanges" json:"exchanges,omitempty"`
}
```

Exchanges can be: zxfq, zxotc, tokenlon, paraswap, kyberswap
eg: `?exchanges=tokenlon,paraswap`