### PR TITLE
handle partial fill for bebop

### DIFF
--- a/pkg/parser/bebop/bebop_test.go
+++ b/pkg/parser/bebop/bebop_test.go
@@ -31,8 +31,8 @@ func TestFetchEvent(t *testing.T) {
 	require.NoError(t, err)
 	logs, err := client.FilterLogs(context.Background(), ethereum.FilterQuery{
 		BlockHash: nil,
-		FromBlock: big.NewInt(20025442),
-		ToBlock:   big.NewInt(20025442),
+		FromBlock: big.NewInt(19932179),
+		ToBlock:   big.NewInt(19932179),
 		Addresses: nil,
 		Topics: [][]common.Hash{
 			{
@@ -46,10 +46,10 @@ func TestFetchEvent(t *testing.T) {
 	t.Log(string(d))
 }
 
-func TestParseEvent(t *testing.T) {
+func TestParseAggregateOrderEvent(t *testing.T) {
 	t.Skip("Need to add the rpc url that enables the trace call JSON-RPC")
-	eventRaw := `[{"address":"0xbbbbbbb520d69a9775e85b458c58c648259fad5f","topics":["0xadd7095becdaa725f0f33243630938c861b0bba83dfd217d4055701aa768ec2e","0x00000000000000000000000000000000b05c492e829fd9c00000000000000000"],"data":"0x","blockNumber":"0x1319062","transactionHash":"0x0f7567ffd5fc92aa552c5e6ebf8173514693aadd5a888c816b4735a931e8c8c3","transactionIndex":"0xe","blockHash":"0x3015d9d1960cab845f333c49f8cb0d81fa89b2c837de8ac22cd645810bb18c83","logIndex":"0x5a","removed":false}]`
-	events := []types.Log{}
+	eventRaw := `{"address":"0xbbbbbbb520d69a9775e85b458c58c648259fad5f","topics":["0xadd7095becdaa725f0f33243630938c861b0bba83dfd217d4055701aa768ec2e","0x000000000000000000000000000000006f0760aefdfe33400000000000000000"],"data":"0x","blockNumber":"0x138de04","transactionHash":"0xb9d13c7057d6d0779a14023d8ce469a8266ea89eb2ca4e6f4c085ef0929c6f08","transactionIndex":"0x8","blockHash":"0x54a780bfa027b8cfb16a40bb86be066795e84d6a124582f9a85b8c662f27fda9","logIndex":"0x46","removed":false}`
+	events := types.Log{}
 	err := json.Unmarshal([]byte(eventRaw), &events)
 	require.NoError(t, err)
 	ethClient, err := ethclient.Dial(rpcURL)
@@ -58,15 +58,59 @@ func TestParseEvent(t *testing.T) {
 	}
 	traceCalls := tracecall.NewCache(rpcnode.NewClient(ethClient))
 	p := MustNewParser(traceCalls)
-	for _, event := range events {
-		log, err := p.Parse(event, uint64(time.Now().Unix()))
-		require.NoError(t, err)
-		require.Equal(t, log.EventHash, p.eventHash)
-		t.Log(log.Maker)
-		t.Log(log.MakerToken)
-		t.Log(log.MakerTokenAmount)
-		t.Log(log.Taker)
-		t.Log(log.TakerToken)
-		t.Log(log.TakerTokenAmount)
+	log, err := p.Parse(events, uint64(time.Now().Unix()))
+	require.NoError(t, err)
+	require.Equal(t, log.EventHash, p.eventHash)
+	t.Log(log.Maker)
+	t.Log(log.MakerToken)
+	t.Log(log.MakerTokenAmount)
+	t.Log(log.Taker)
+	t.Log(log.TakerToken)
+	t.Log(log.TakerTokenAmount)
+}
+
+func TestParseMultiOrderEvent(t *testing.T) {
+	t.Skip("Need to add the rpc url that enables the trace call JSON-RPC")
+	eventRaw := `{"address":"0xbbbbbbb520d69a9775e85b458c58c648259fad5f","topics":["0xadd7095becdaa725f0f33243630938c861b0bba83dfd217d4055701aa768ec2e","0x0000000000000000000000000000000027611cb25303fa700000000000000001"],"data":"0x","blockNumber":"0x133842c","transactionHash":"0xff46ac555ec7da7aa484864dc0df90217b7f46dfa51627c20ef6e25451c64b15","transactionIndex":"0x10","blockHash":"0xb03cd01d48456c60cdf445e35b0a4d7672b80d801245e516336596f0d5b77951","logIndex":"0x85","removed":false}`
+	events := types.Log{}
+	err := json.Unmarshal([]byte(eventRaw), &events)
+	require.NoError(t, err)
+	ethClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		panic(err)
 	}
+	traceCalls := tracecall.NewCache(rpcnode.NewClient(ethClient))
+	p := MustNewParser(traceCalls)
+	log, err := p.Parse(events, uint64(time.Now().Unix()))
+	require.NoError(t, err)
+	require.Equal(t, log.EventHash, p.eventHash)
+	t.Log(log.Maker)
+	t.Log(log.MakerToken)
+	t.Log(log.MakerTokenAmount)
+	t.Log(log.Taker)
+	t.Log(log.TakerToken)
+	t.Log(log.TakerTokenAmount)
+}
+
+func TestParseSingleOrderEvent(t *testing.T) {
+	t.Skip("Need to add the rpc url that enables the trace call JSON-RPC")
+	eventRaw := `{"address":"0xbbbbbbb520d69a9775e85b458c58c648259fad5f","topics":["0xadd7095becdaa725f0f33243630938c861b0bba83dfd217d4055701aa768ec2e","0x0000000000000000000000000000000084e2ab041ba07e400000000000000000"],"data":"0x","blockNumber":"0x1302413","transactionHash":"0xa227c4aed6f3ae86cd8ba02349d0ae5be78337266416ac65cf8a8d095a2f572e","transactionIndex":"0x47","blockHash":"0xbb4a5ae13e2a66f83f444f24078ac3fb6d0b09f610c48d920d3b89d4f20ea86c","logIndex":"0xd8","removed":false}`
+	events := types.Log{}
+	err := json.Unmarshal([]byte(eventRaw), &events)
+	require.NoError(t, err)
+	ethClient, err := ethclient.Dial(rpcURL)
+	if err != nil {
+		panic(err)
+	}
+	traceCalls := tracecall.NewCache(rpcnode.NewClient(ethClient))
+	p := MustNewParser(traceCalls)
+	log, err := p.Parse(events, uint64(time.Now().Unix()))
+	require.NoError(t, err)
+	require.Equal(t, log.EventHash, p.eventHash)
+	t.Log(log.Maker)
+	t.Log(log.MakerToken)
+	t.Log(log.MakerTokenAmount)
+	t.Log(log.Taker)
+	t.Log(log.TakerToken)
+	t.Log(log.TakerTokenAmount)
 }

--- a/pkg/parser/bebop/parser.go
+++ b/pkg/parser/bebop/parser.go
@@ -221,6 +221,7 @@ func (p *Parser) ParseFromInternalCall(order storage.TradeLog, internalCall type
 		case p.aggregateOrderFunc.Has(contractCall.Name):
 			return p.parseAggregateSwap(order, contractCall, param, filledTakerAmount)
 		}
+		break
 	}
 
 	return order, nil
@@ -285,10 +286,10 @@ func (p *Parser) LogFromExchange(log ethereumTypes.Log) bool {
 
 func (p *Parser) parseSingleSwap(order storage.TradeLog,
 	contractCall *tradingTypes.ContractCall,
-	param tradingTypes.ContractCallParam,
+	orderParam tradingTypes.ContractCallParam,
 	fillTakerAmount *big.Int) (storage.TradeLog, error) {
 	var rfqOrder SingleOrder
-	if err := unpackOrder(param.Value, &rfqOrder); err != nil {
+	if err := unpackOrder(orderParam.Value, &rfqOrder); err != nil {
 		return order, err
 	}
 
@@ -297,7 +298,7 @@ func (p *Parser) parseSingleSwap(order storage.TradeLog,
 			continue
 		}
 		var oldOrder OldSingleQuote
-		if err := unpackOrder(param.Value, &oldOrder); err == nil {
+		if err := unpackOrder(param.Value, &oldOrder); err == nil && oldOrder.UseOldAmount {
 			rfqOrder.MakerAmount = oldOrder.MakerAmount
 		}
 		break
@@ -324,10 +325,10 @@ func (p *Parser) parseSingleSwap(order storage.TradeLog,
 
 func (p *Parser) parseMultiSwap(order storage.TradeLog,
 	contractCall *tradingTypes.ContractCall,
-	param tradingTypes.ContractCallParam,
+	orderParam tradingTypes.ContractCallParam,
 	fillTakerAmount *big.Int) (storage.TradeLog, error) {
 	var rfqOrder MultiOrder
-	if err := unpackOrder(param.Value, &rfqOrder); err != nil {
+	if err := unpackOrder(orderParam.Value, &rfqOrder); err != nil {
 		return order, err
 	}
 
@@ -336,7 +337,7 @@ func (p *Parser) parseMultiSwap(order storage.TradeLog,
 			continue
 		}
 		var oldOrder OldMultiQuote
-		if err := unpackOrder(param.Value, &oldOrder); err == nil {
+		if err := unpackOrder(param.Value, &oldOrder); err == nil && oldOrder.UseOldAmount {
 			rfqOrder.MakerAmounts = oldOrder.MakerAmounts
 		}
 		break
@@ -371,11 +372,11 @@ func (p *Parser) parseMultiSwap(order storage.TradeLog,
 
 func (p *Parser) parseAggregateSwap(order storage.TradeLog,
 	contractCall *tradingTypes.ContractCall,
-	param tradingTypes.ContractCallParam,
+	orderParam tradingTypes.ContractCallParam,
 	filledTakerAmount *big.Int) (storage.TradeLog, error) {
 
 	var rfqOrder AggregateOrder
-	if err := unpackOrder(param.Value, &rfqOrder); err != nil {
+	if err := unpackOrder(orderParam.Value, &rfqOrder); err != nil {
 		return order, err
 	}
 
@@ -384,7 +385,7 @@ func (p *Parser) parseAggregateSwap(order storage.TradeLog,
 			continue
 		}
 		var oldOrder OldAggregateQuote
-		if err := unpackOrder(param.Value, &oldOrder); err == nil {
+		if err := unpackOrder(param.Value, &oldOrder); err == nil && oldOrder.UseOldAmount {
 			rfqOrder.MakerAmounts = oldOrder.MakerAmounts
 		}
 		break

--- a/pkg/parser/bebop/parser.go
+++ b/pkg/parser/bebop/parser.go
@@ -204,6 +204,7 @@ func (p *Parser) ParseFromInternalCall(order storage.TradeLog, internalCall type
 		if ok {
 			filledTakerAmount = v
 		}
+		break
 	}
 	if filledTakerAmount == nil {
 		return order, ErrParamNotFound
@@ -299,6 +300,7 @@ func (p *Parser) parseSingleSwap(order storage.TradeLog,
 		if err := unpackOrder(param.Value, &oldOrder); err == nil {
 			rfqOrder.MakerAmount = oldOrder.MakerAmount
 		}
+		break
 	}
 
 	if fillTakerAmount.Cmp(big.NewInt(0)) > 0 && fillTakerAmount.Cmp(rfqOrder.TakerAmount) < 0 {
@@ -337,6 +339,7 @@ func (p *Parser) parseMultiSwap(order storage.TradeLog,
 		if err := unpackOrder(param.Value, &oldOrder); err == nil {
 			rfqOrder.MakerAmounts = oldOrder.MakerAmounts
 		}
+		break
 	}
 
 	if len(rfqOrder.TakerTokens) == 1 { // many to one don't support partial, just handle one - many
@@ -384,7 +387,7 @@ func (p *Parser) parseAggregateSwap(order storage.TradeLog,
 		if err := unpackOrder(param.Value, &oldOrder); err == nil {
 			rfqOrder.MakerAmounts = oldOrder.MakerAmounts
 		}
-
+		break
 	}
 	quoteTakerAmount := getAggregateOrderInfo(rfqOrder)
 	if filledTakerAmount.Cmp(big.NewInt(0)) > 0 && filledTakerAmount.Cmp(quoteTakerAmount) < 0 {


### PR DESCRIPTION
What is the problem?
Bebop integration support fill partial order, current code only parse original order. So, our trade data was not correct.

What did you do?
Update logic for partial order:
-filledTakerAmount: this is actual amount, taker want to swap
-takerQuoteInfo: old order contain old maker amount

Refer contract: https://vscode.blockscan.com/ethereum/0xbbbbbbb520d69a9775e85b458c58c648259fad5f