### PR TITLE
fix 0xv3 backfill task not running

### DIFF
--- a/v2/pkg/rpcnode/client.go
+++ b/v2/pkg/rpcnode/client.go
@@ -122,10 +122,14 @@ func (c *Client) FetchLogs(ctx context.Context, from, to uint64, address string,
 		logs []ethereumTypes.Log
 		err  error
 	)
+	var addresses []common.Address
+	if len(address) > 0 {
+		addresses = append(addresses, common.HexToAddress(address))
+	}
 	filter := ethereum.FilterQuery{
 		FromBlock: new(big.Int).SetUint64(from),
 		ToBlock:   new(big.Int).SetUint64(to),
-		Addresses: []common.Address{common.HexToAddress(address)},
+		Addresses: addresses,
 	}
 	newTopics := make([]common.Hash, len(topics))
 	if len(topics) > 0 {


### PR DESCRIPTION
Currently, when we create new backfill task for exchange 0xv3, the task is not running due to blank address filter leading to empty logs response. So I updated the filter to pass empty address param when address = "" in case of 0xv3.